### PR TITLE
Laravel 5.* Updates

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,5 +22,15 @@
     "require-dev": {
         "phpunit/phpunit": "^6.3",
         "orchestra/testbench": "~3.0"
+    },
+    "extra": {
+        "laravel": {
+            "providers": [
+                "Arkhas\\Calendar\\CalendarServiceProvider"
+            ],
+            "aliases": {
+                "Calendar": "Arkhas\\Calendar\\Facades\\Calendar"
+            }
+        }
     }
 }

--- a/src/CalendarServiceProvider.php
+++ b/src/CalendarServiceProvider.php
@@ -31,7 +31,7 @@ class CalendarServiceProvider extends ServiceProvider
     {
         include __DIR__.'/routes.php';
         $this->app->make('Arkhas\Calendar\CalendarController');
-        $this->app['calendar'] = $this->app->share(function ($app) {
+        $this->app->singleton('calendar', function ($app) {
             return new Calendar();
         });
     }


### PR DESCRIPTION
Composer file is for Laravel 5.5 updates. This should publish the provider and facade automagically.

The service provider change is because it appears Laravel has updated the way to register the custom class into Laravel. Not sure since what version of Laravel has been using singleton and not bind. 